### PR TITLE
公開用CIの作成、tgzをuroborosql-fmtのgithub.ioから参照するように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - run: npm install
+      - run: |
+          cd server
+          wget https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-0.0.0.tgz
+          cd ..
+          npm install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm_config_arch: ${{ matrix.npm_config_arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
             platform: win32
             arch: x64
             npm_config_arch: x64
-          - os: windows-latest
-            platform: win32
-            arch: ia32
-            npm_config_arch: ia32
+          # - os: windows-latest
+          #   platform: win32
+          #   arch: ia32
+          #   npm_config_arch: ia32
           - os: windows-latest
             platform: win32
             arch: arm64
@@ -21,18 +21,18 @@ jobs:
             platform: linux
             arch: x64
             npm_config_arch: x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: arm64
-            npm_config_arch: arm64
-          - os: ubuntu-latest
-            platform: linux
-            arch: armhf
-            npm_config_arch: arm
-          - os: ubuntu-latest
-            platform: alpine
-            arch: x64
-            npm_config_arch: x64
+          # - os: ubuntu-latest
+          #   platform: linux
+          #   arch: arm64
+          #   npm_config_arch: arm64
+          # - os: ubuntu-latest
+          #   platform: linux
+          #   arch: armhf
+          #   npm_config_arch: arm
+          # - os: ubuntu-latest
+          #   platform: alpine
+          #   arch: x64
+          #   npm_config_arch: x64
           - os: macos-latest
             platform: darwin
             arch: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,38 +5,38 @@ jobs:
     strategy:
       matrix:
         include:
-          # - os: windows-latest
-          #   platform: win32
-          #   arch: x64
-          #   npm_config_arch: x64
+          - os: windows-latest
+            platform: win32
+            arch: x64
+            npm_config_arch: x64
           # - os: windows-latest
           #   platform: win32
           #   arch: ia32
           #   npm_config_arch: ia32
-          # - os: windows-latest
-          #   platform: win32
-          #   arch: arm64
-          #   npm_config_arch: arm
-          # - os: ubuntu-latest
-          #   platform: linux
-          #   arch: x64
-          #   npm_config_arch: x64
-          # - os: ubuntu-latest
-          #   platform: linux
-          #   arch: arm64
-          #   npm_config_arch: arm64
-          # - os: ubuntu-latest
-          #   platform: linux
-          #   arch: armhf
-          #   npm_config_arch: arm
+          - os: windows-latest
+            platform: win32
+            arch: arm64
+            npm_config_arch: arm
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+            npm_config_arch: x64
+          - os: ubuntu-latest
+            platform: linux
+            arch: arm64
+            npm_config_arch: arm64
+          - os: ubuntu-latest
+            platform: linux
+            arch: armhf
+            npm_config_arch: arm
           # - os: ubuntu-latest
           #   platform: alpine
           #   arch: x64
           #   npm_config_arch: x64
-          # - os: macos-latest
-          #   platform: darwin
-          #   arch: x64
-          #   npm_config_arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: x64
+            npm_config_arch: x64
           - os: macos-latest
             platform: darwin
             arch: arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
             platform: win32
             arch: x64
             npm_config_arch: x64
-          # - os: windows-latest
-          #   platform: win32
-          #   arch: ia32
-          #   npm_config_arch: ia32
+          - os: windows-latest
+            platform: win32
+            arch: ia32
+            npm_config_arch: ia32
           - os: windows-latest
             platform: win32
             arch: arm64
@@ -29,10 +29,10 @@ jobs:
             platform: linux
             arch: armhf
             npm_config_arch: arm
-          # - os: ubuntu-latest
-          #   platform: alpine
-          #   arch: x64
-          #   npm_config_arch: x64
+          - os: ubuntu-latest
+            platform: alpine
+            arch: x64
+            npm_config_arch: x64
           - os: macos-latest
             platform: darwin
             arch: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
-    # if: success()
+    if: success()
     steps:
       - uses: actions/download-artifact@v2
       - run: npx vsce publish --packagePath $(find . -iname *.vsix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request: null
+on: push
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request: null
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: 14.x
       - run: |
           cd server
-          wget https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-0.0.0.tgz
+          curl -OL https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-0.0.0.tgz
           cd ..
           npm install
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
-    if: success()
+    # if: success()
     steps:
       - uses: actions/download-artifact@v2
       - run: npx vsce publish --packagePath $(find . -iname *.vsix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
             platform: win32
             arch: x64
             npm_config_arch: x64
-          - os: windows-latest
-            platform: win32
-            arch: ia32
-            npm_config_arch: ia32
+          # - os: windows-latest
+          #   platform: win32
+          #   arch: ia32
+          #   npm_config_arch: ia32
           - os: windows-latest
             platform: win32
             arch: arm64
@@ -29,10 +29,10 @@ jobs:
             platform: linux
             arch: armhf
             npm_config_arch: arm
-          - os: ubuntu-latest
-            platform: alpine
-            arch: x64
-            npm_config_arch: x64
+          # - os: ubuntu-latest
+          #   platform: alpine
+          #   arch: x64
+          #   npm_config_arch: x64
           - os: macos-latest
             platform: darwin
             arch: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,38 +5,38 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
-            platform: win32
-            arch: x64
-            npm_config_arch: x64
+          # - os: windows-latest
+          #   platform: win32
+          #   arch: x64
+          #   npm_config_arch: x64
           # - os: windows-latest
           #   platform: win32
           #   arch: ia32
           #   npm_config_arch: ia32
-          - os: windows-latest
-            platform: win32
-            arch: arm64
-            npm_config_arch: arm
-          - os: ubuntu-latest
-            platform: linux
-            arch: x64
-            npm_config_arch: x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: arm64
-            npm_config_arch: arm64
-          - os: ubuntu-latest
-            platform: linux
-            arch: armhf
-            npm_config_arch: arm
+          # - os: windows-latest
+          #   platform: win32
+          #   arch: arm64
+          #   npm_config_arch: arm
+          # - os: ubuntu-latest
+          #   platform: linux
+          #   arch: x64
+          #   npm_config_arch: x64
+          # - os: ubuntu-latest
+          #   platform: linux
+          #   arch: arm64
+          #   npm_config_arch: arm64
+          # - os: ubuntu-latest
+          #   platform: linux
+          #   arch: armhf
+          #   npm_config_arch: arm
           # - os: ubuntu-latest
           #   platform: alpine
           #   arch: x64
           #   npm_config_arch: x64
-          - os: macos-latest
-            platform: darwin
-            arch: x64
-            npm_config_arch: x64
+          # - os: macos-latest
+          #   platform: darwin
+          #   arch: x64
+          #   npm_config_arch: x64
           - os: macos-latest
             platform: darwin
             arch: arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request: null
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win32
+            arch: x64
+            npm_config_arch: x64
+          - os: windows-latest
+            platform: win32
+            arch: ia32
+            npm_config_arch: ia32
+          - os: windows-latest
+            platform: win32
+            arch: arm64
+            npm_config_arch: arm
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+            npm_config_arch: x64
+          - os: ubuntu-latest
+            platform: linux
+            arch: arm64
+            npm_config_arch: arm64
+          - os: ubuntu-latest
+            platform: linux
+            arch: armhf
+            npm_config_arch: arm
+          - os: ubuntu-latest
+            platform: alpine
+            arch: x64
+            npm_config_arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: x64
+            npm_config_arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: arm64
+            npm_config_arch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - run: npm install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          npm_config_arch: ${{ matrix.npm_config_arch }}
+      - shell: pwsh
+        run: echo "target=${{ matrix.platform }}-${{ matrix.arch }}" >> $env:GITHUB_ENV
+      - run: npx vsce package --target ${{ env.target }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.target }}
+          path: "*.vsix"
+
+  # 成果物をダウンロードしてpublish
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: success()
+    steps:
+      - uses: actions/download-artifact@v2
+      - run: npx vsce publish --packagePath $(find . -iname *.vsix)
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Publish
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 on:
   push:
-    branches:
-      - main
-  pull_request: null
+    tags:
+      - "*"
 jobs:
   build:
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # uroboroSQL-fmt for VSCode
 
-![logo](https://github.com/future-architect/vscode-uroborosql-fmt/tree/main/images/logo.png)
+![logo](./images/logo.png)
 
-![demo](https://github.com/future-architect/vscode-uroborosql-fmt/tree/main/images/demo.gif)
+![demo](./images/demo.gif)
 
 A Visual Studio Code extension for [uroboroSQL-fmt](https://github.com/future-architect/uroborosql-fmt) that is a tool that formats SQL statements according to [SQL coding standards created by Future Corporation](https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html) (Japanese only).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "SQL formatter with 2way-sql support",
   "author": "Future Corporation",
   "license": "BUSL-1.1",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/future-architect/vscode-uroborosql-fmt.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "SQL formatter with 2way-sql support",
   "author": "Future Corporation",
   "license": "BUSL-1.1",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/future-architect/vscode-uroborosql-fmt.git"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,7 +27,7 @@
     "node_modules/uroborosql-fmt-napi": {
       "version": "0.0.0",
       "resolved": "file:uroborosql-fmt-napi-0.0.0.tgz",
-      "integrity": "sha512-YzXqpPucO4tBjxwubwb2ZSB1oists1qYGqgkX7wqC6OltNbCsKQEgG80c0EMdqbF1+zLtbS4TCRTBF8mI/gdxA==",
+      "integrity": "sha512-nnSH9hfQo8GuyeVlDtNWhmqb7pGguK4CAPXnVeAZfCe/5rHJdGQ3z9j1IhGrxmQzjsZ/2BLqHN6NfyX7gLrYUg==",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">= 10"


### PR DESCRIPTION
## 公開用CIの作成

VSCode拡張機能として公開するためのCI.ymlを作成しました。[公式のCI.yml](https://github.com/microsoft/vscode-platform-specific-sample/blob/main/.github/workflows/ci.yml)を参考に作成しています。

未対応のプラットフォームに関しては、今後対応する可能性を考えてコメントアウトしています。

## `uroborosql-fmt-napi-0.0.0.tgz`をダウンロードで持ってくるように変更

`https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-0.0.0.tgz`に公開されているtgzをcurlで持ってきてビルド -> 公開するように変更しました。

## 画像のパスを変更
画像を相対パスで参照するように変更しました。

Close #3