### PR TITLE
fix: add uroborosql-fmt-napi-0.0.0.tgz  to .vscodeignore

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,8 @@ module.exports = {
 		'@typescript-eslint/no-explicit-any': 0,
 		'@typescript-eslint/explicit-module-boundary-types': 0,
 		'@typescript-eslint/no-non-null-assertion': 0,
+	},
+	env: {
+		node: true
 	}
 };

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,9 +51,6 @@ jobs:
         with:
           node-version: 14.x
       - run: |
-          cd server
-          curl -OL https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-0.0.0.tgz
-          cd ..
           npm install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 client/server
 .vscode-test
 uroborosql-fmt-1.0.0.vsix
+/server/uroborosql-fmt-napi-0.0.0.tgz

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,3 +13,4 @@ client/node_modules/**
 !client/node_modules/vscode-languageserver-types/**
 !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
 !client/node_modules/{semver,lru-cache,yallist}/**
+/server/uroborosql-fmt-napi-0.0.0.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uroborosql-fmt",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uroborosql-fmt",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "devDependencies": {
@@ -16,6 +16,7 @@
         "@typescript-eslint/parser": "^5.30.0",
         "eslint": "^8.13.0",
         "mocha": "^9.2.1",
+        "tunnel-agent": "^0.6.0",
         "typescript": "^4.8.4"
       },
       "engines": {
@@ -1980,6 +1981,18 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@typescript-eslint/parser": "^5.30.0",
         "eslint": "^8.13.0",
         "mocha": "^9.2.1",
-        "tunnel-agent": "^0.6.0",
         "typescript": "^4.8.4"
       },
       "engines": {
@@ -1981,18 +1980,6 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@typescript-eslint/parser": "^5.30.0",
     "eslint": "^8.13.0",
     "mocha": "^9.2.1",
-    "tunnel-agent": "^0.6.0",
     "typescript": "^4.8.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
     "compile": "tsc -b",
     "watch": "tsc -b -w",
     "lint": "eslint ./client/src ./server/src --ext .ts,.tsx",
-    "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
-    "test": "sh ./scripts/e2e.sh"
+    "postinstall": "npm run download-uroborosql-fmt-napi && cd client && npm install && cd ../server && npm install && cd ..",
+    "test": "sh ./scripts/e2e.sh",
+    "download-uroborosql-fmt-napi": "node ./server/download-uroborosql-fmt-napi.mjs"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
@@ -58,6 +59,7 @@
     "@typescript-eslint/parser": "^5.30.0",
     "eslint": "^8.13.0",
     "mocha": "^9.2.1",
+    "tunnel-agent": "^0.6.0",
     "typescript": "^4.8.4"
   }
 }

--- a/server/download-uroborosql-fmt-napi.mjs
+++ b/server/download-uroborosql-fmt-napi.mjs
@@ -1,7 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import tunnel from "tunnel-agent";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/download-uroborosql-fmt-napi.mjs
+++ b/server/download-uroborosql-fmt-napi.mjs
@@ -1,0 +1,17 @@
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import tunnel from "tunnel-agent";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+main();
+
+async function main() {
+  const res = await fetch(
+    "https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-0.0.0.tgz"
+  );
+  const destination = join(__dirname, "uroborosql-fmt-napi-0.0.0.tgz");
+  writeFileSync(destination, Buffer.from(await res.arrayBuffer()));
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,8 +27,8 @@
     "node_modules/uroborosql-fmt-napi": {
       "version": "0.0.0",
       "resolved": "file:uroborosql-fmt-napi-0.0.0.tgz",
-      "integrity": "sha512-nnSH9hfQo8GuyeVlDtNWhmqb7pGguK4CAPXnVeAZfCe/5rHJdGQ3z9j1IhGrxmQzjsZ/2BLqHN6NfyX7gLrYUg==",
-      "license": "BUSL-1.1",
+      "integrity": "sha512-TxLZ6vLiVTuyQjtW7z0u6lX8HCJHL5euskAbF9PRGknGtspudV/QEzduJ2XfQHnmGou3ctyJ9OvXss7p3SHSCQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }


### PR DESCRIPTION
fixes #5

uroborosql-fmt-napi-0.0.0.tgzを.vscodeignoreに追加します。
また、ローカルでも簡単にuroborosql-fmt-napi-0.0.0.tgzをダインロードできるようにインストール構成を変更しました。