### PR TITLE
fix: add uroborosql-fmt-napi-0.0.0.tgz to .vscodeignore (take 2)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,4 +13,4 @@ client/node_modules/**
 !client/node_modules/vscode-languageserver-types/**
 !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
 !client/node_modules/{semver,lru-cache,yallist}/**
-/server/uroborosql-fmt-napi-0.0.0.tgz
+server/uroborosql-fmt-napi-0.0.0.tgz


### PR DESCRIPTION
fixes #5

前の修正は、.gitignoreで認識しても.vscodeignoreでは認識しないフォーマットだったようです。

このPRはそれをさらに修正します。 
この変更を加えたあと `npx vsce package` で作成したvsixファイルをtgzとして解凍し、uroborosql-fmt-napi-0.0.0.tgzが含まれないことを確認しました。