### PR TITLE
バージョンアップ時にタグとリリースの作成を自動で行う

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,7 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
+        with:
+          publish: npm run dummy-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "format:check": "prettier --cache --check .",
     "postinstall": "npm run download-uroborosql-fmt-napi && cd client && npm install && cd ../server && npm install && cd ..",
     "test": "sh ./scripts/e2e.sh",
-    "download-uroborosql-fmt-napi": "node ./server/download-uroborosql-fmt-napi.mjs"
+    "download-uroborosql-fmt-napi": "node ./server/download-uroborosql-fmt-napi.mjs",
+    "dummy-release": "echo \"New tag:\" && exit 0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postinstall": "npm run download-uroborosql-fmt-napi && cd client && npm install && cd ../server && npm install && cd ..",
     "test": "sh ./scripts/e2e.sh",
     "download-uroborosql-fmt-napi": "node ./server/download-uroborosql-fmt-napi.mjs",
-    "dummy-release": "echo \"New tag:\" && exit 0"
+    "dummy-release": "node ./scripts/dummy-publish.mjs"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/scripts/dummy-publish.mjs
+++ b/scripts/dummy-publish.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import * as cp from "child_process";
+
+main();
+
+// 既に作成済みのバージョンのtagを再度作成しようとしてgithub actionが失敗するのを防ぐため
+// tag作成が必要な場合のみ"New tag:"を出力する
+function main() {
+  cp.execSync("git fetch --tags origin");
+
+  const tags = cp.execSync("git tag").toString().split("\n");
+  const changelog = readFileSync("CHANGELOG.md", "utf8");
+
+  const latestVersion = changelog.match(/^## (?<version>\d\.\d\.\d)/m);
+
+  if (!tags.includes(`v${latestVersion.groups.version}`)) {
+    console.log('"New tag:"');
+  }
+}


### PR DESCRIPTION
[changesets/action](https://github.com/changesets/action)はタグとリリースを作成する前にnpm publishを実行する前提になっており、vscode-uroborosql-fmtはリリース時にnpm publishを実行しないため、バージョンアップ時にgithub actionでタグとリリースを作成出来ていなかった。  
この[issue](https://github.com/changesets/action/issues/269)を参考に、バージョンアップ時にgithub actionでタグとリリースを自動的に作成するよう対応する。

#21 