### PR TITLE
fix: release workflowでtag作成してもpublish workflowが実行されない不具合修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,14 @@ jobs:
         run: yarn
 
       - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: npm run dummy-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Invoke publish.yml
+        if: steps.changesets.outputs.published == 'true'
+        uses: ./.github/workflows/publish.yaml
+        secrets: inherit

--- a/scripts/dummy-publish.mjs
+++ b/scripts/dummy-publish.mjs
@@ -9,11 +9,9 @@ function main() {
   cp.execSync("git fetch --tags origin");
 
   const tags = cp.execSync("git tag").toString().split("\n");
-  const changelog = readFileSync("CHANGELOG.md", "utf8");
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 
-  const latestVersion = changelog.match(/^## (?<version>\d\.\d\.\d)/m);
-
-  if (!tags.includes(`v${latestVersion.groups.version}`)) {
+  if (!tags.includes(`v${pkg["version"]}`)) {
     console.log('"New tag:"');
   }
 }


### PR DESCRIPTION
1. release workflowでtag作成してもpublish workflowがトリガーされない問題に対応するため、release workflowからpublish workflowを呼び出すように変更しました
2. scripts\dummy-publish.mjsの処理がシンプルになるよう変更しました
