### PR TITLE
Fix format even if workspace folder cannot be obtained

### DIFF
--- a/.changeset/popular-doors-film.md
+++ b/.changeset/popular-doors-film.md
@@ -1,0 +1,5 @@
+---
+"uroborosql-fmt": patch
+---
+
+Allow formatting even if the workspace folder cannot be obtained

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -183,11 +183,6 @@ async function formatText(
   version: number,
   selections: Range[],
 ): Promise<TextEdit[]> {
-  // version check
-  if (version !== textDocument.version) {
-    return [];
-  }
-
   let configPath: string | null;
 
   try {
@@ -197,6 +192,11 @@ async function formatText(
       connection.window.showErrorMessage(e.message);
     }
 
+    return [];
+  }
+
+  // version check
+  if (version !== textDocument.version) {
     return [];
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -133,55 +133,71 @@ async function getWorkspaceFolder(
   return undefined;
 }
 
+async function determineConfigPath(
+  uri: string,
+  textDocument: TextDocument,
+): Promise<string | null> {
+  const workspaceFolder: string | undefined =
+    await getWorkspaceFolder(textDocument);
+
+  if (!workspaceFolder) {
+    return null;
+  }
+
+  const workspaceFolderPath = URI.parse(workspaceFolder).fsPath;
+
+  const settings: ConfigurationSettings = await getSettings(uri);
+  if (!settings.configurationFilePath) {
+    // remove scheme
+    const defaultConfigPath = path.join(
+      workspaceFolderPath,
+      ".uroborosqlfmtrc.json",
+    );
+
+    // The path of configuration file is not specified.
+    // If defaultConfigPath doesn't exist, fomatters default config will be used.
+    if (!fs.existsSync(defaultConfigPath)) {
+      return null;
+    }
+
+    return defaultConfigPath;
+  }
+
+  let specifiedConfigPath = settings.configurationFilePath;
+  if (!path.isAbsolute(specifiedConfigPath)) {
+    specifiedConfigPath = path.join(workspaceFolderPath, specifiedConfigPath);
+  }
+
+  if (!fs.existsSync(specifiedConfigPath)) {
+    // If the path is explicitly specified but the file does not exist,
+    // it is not formatted and an error is generated.
+    throw new Error(`${specifiedConfigPath} doesn't exist.`);
+  }
+
+  return specifiedConfigPath;
+}
+
 async function formatText(
   uri: string,
   textDocument: TextDocument,
   version: number,
   selections: Range[],
 ): Promise<TextEdit[]> {
-  const settings: ConfigurationSettings = await getSettings(uri);
-
-  const workspaceFolder: string | undefined =
-    await getWorkspaceFolder(textDocument);
-  if (!workspaceFolder) {
-    connection.window.showErrorMessage("The workspace folder is undefined");
-    return [];
-  }
-
   // version check
   if (version !== textDocument.version) {
     return [];
   }
 
-  // remove scheme
-  const workspaceFolderPath = URI.parse(workspaceFolder).fsPath;
-  const defaultConfigPath = path.join(
-    workspaceFolderPath,
-    ".uroborosqlfmtrc.json",
-  );
+  let configPath: string | null;
 
-  let configPath: string | null = null;
-  if (!settings.configurationFilePath) {
-    // The path of configuration file is not specified.
-    // If defaultConfigPath doesn't exist, fomatters default config will be used.
-    if (fs.existsSync(defaultConfigPath)) {
-      configPath = defaultConfigPath;
-    }
-    // else { configPath = null; }
-  } else {
-    let specifiedConfigPath = settings.configurationFilePath;
-    if (!path.isAbsolute(specifiedConfigPath)) {
-      specifiedConfigPath = path.join(workspaceFolderPath, specifiedConfigPath);
+  try {
+    configPath = await determineConfigPath(uri, textDocument);
+  } catch (e) {
+    if (e instanceof Error) {
+      connection.window.showErrorMessage(e.message);
     }
 
-    if (fs.existsSync(specifiedConfigPath)) {
-      configPath = specifiedConfigPath;
-    } else {
-      connection.window.showErrorMessage(
-        `${specifiedConfigPath} doesn't exist.`,
-      );
-      return [];
-    }
+    return [];
   }
 
   const changes: TextEdit[] = [];
@@ -194,27 +210,27 @@ async function formatText(
       continue;
     }
 
-    let formatted_text: string;
+    let formattedText: string;
 
     try {
-      formatted_text = runfmt(text, configPath);
+      formattedText = runfmt(text, configPath);
     } catch (e) {
       console.error(e);
       return [];
     }
 
     // フォーマット
-    changes.push(TextEdit.replace(selection, formatted_text));
+    changes.push(TextEdit.replace(selection, formattedText));
   }
 
   if (!changes.length) {
     // テキスト全体を取得
     const text = textDocument.getText();
 
-    let formatted_text: string;
+    let formattedText: string;
     const startTime = performance.now();
     try {
-      formatted_text = runfmt(text, configPath);
+      formattedText = runfmt(text, configPath);
     } catch (e) {
       console.error(e);
       connection.window.showErrorMessage(
@@ -233,7 +249,7 @@ async function formatText(
           Position.create(0, 0),
           textDocument.positionAt(text.length),
         ),
-        formatted_text,
+        formattedText,
       ),
     );
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -144,11 +144,11 @@ async function determineConfigPath(
     return null;
   }
 
+  // remove scheme
   const workspaceFolderPath = URI.parse(workspaceFolder).fsPath;
 
   const settings: ConfigurationSettings = await getSettings(uri);
   if (!settings.configurationFilePath) {
-    // remove scheme
     const defaultConfigPath = path.join(
       workspaceFolderPath,
       ".uroborosqlfmtrc.json",


### PR DESCRIPTION
workspace folderが取得できない場合でも、デフォルト設定でフォーマットするよう変更しました。
workspace folderが取得できた場合の挙動は変更前後で変わらないようにしています。

また、スネークケースの変数があったのでついでに直しています。
