### PR TITLE
フォーマットエラー時にステータスバーのアイコンの背景色で通知するように変更

### DIFF
--- a/.changeset/gentle-flies-own.md
+++ b/.changeset/gentle-flies-own.md
@@ -1,0 +1,5 @@
+---
+"uroborosql-fmt": minor
+---
+
+Improved to notify the status bar when formatting errors.

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -78,6 +78,7 @@ export function activate(context: ExtensionContext) {
       statusBar.backgroundColor = new ThemeColor(
         "statusBarItem.warningBackground"
       );
+      statusBar.text = "$(warning) Uroborosql-fmt"
     });
 
     // ステータスバーの背景色を赤色に変更
@@ -85,6 +86,7 @@ export function activate(context: ExtensionContext) {
       statusBar.backgroundColor = new ThemeColor(
         "statusBarItem.errorBackground"
       );
+      statusBar.text = "$(alert) Uroborosql-fmt"
     })
 
     // ステータスバーの背景色を通常色に変更
@@ -92,6 +94,7 @@ export function activate(context: ExtensionContext) {
       statusBar.backgroundColor = new ThemeColor(
         "statusBarItem.fourgroundBackground"
       );
+      statusBar.text = "Uroborosql-fmt"
     })
   })
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,13 @@
 import * as path from "path";
-import { workspace, ExtensionContext, window, commands, StatusBarAlignment, ThemeColor, StatusBarItem } from "vscode";
+import {
+  workspace,
+  ExtensionContext,
+  window,
+  commands,
+  StatusBarAlignment,
+  ThemeColor,
+  StatusBarItem,
+} from "vscode";
 
 import {
   LanguageClient,
@@ -66,8 +74,6 @@ export function activate(context: ExtensionContext) {
     }),
   );
 
-
-
   // ステータスバーの作成と表示
   const statusBar = createStatusBar();
   statusBar.show();
@@ -76,27 +82,27 @@ export function activate(context: ExtensionContext) {
     // ステータスバーの背景色を黄色に変更
     client.onRequest("custom/warning", () => {
       statusBar.backgroundColor = new ThemeColor(
-        "statusBarItem.warningBackground"
+        "statusBarItem.warningBackground",
       );
-      statusBar.text = "$(warning) Uroborosql-fmt"
+      statusBar.text = "$(warning) Uroborosql-fmt";
     });
 
     // ステータスバーの背景色を赤色に変更
     client.onRequest("custom/error", () => {
       statusBar.backgroundColor = new ThemeColor(
-        "statusBarItem.errorBackground"
+        "statusBarItem.errorBackground",
       );
-      statusBar.text = "$(alert) Uroborosql-fmt"
-    })
+      statusBar.text = "$(alert) Uroborosql-fmt";
+    });
 
     // ステータスバーの背景色を通常色に変更
     client.onRequest("custom/normal", () => {
       statusBar.backgroundColor = new ThemeColor(
-        "statusBarItem.fourgroundBackground"
+        "statusBarItem.fourgroundBackground",
       );
-      statusBar.text = "Uroborosql-fmt"
-    })
-  })
+      statusBar.text = "Uroborosql-fmt";
+    });
+  });
 
   // Start the client. This will also launch the server
   client.start();
@@ -109,9 +115,9 @@ function createStatusBar(): StatusBarItem {
   });
 
   const statusBar = window.createStatusBarItem(StatusBarAlignment.Right, 100);
-  statusBar.text = 'Uroborosql-fmt';
-  statusBar.name = 'Uroborosql-fmt';
-  statusBar.command = 'uroborosql-fmt.show-output'
+  statusBar.text = "Uroborosql-fmt";
+  statusBar.name = "Uroborosql-fmt";
+  statusBar.command = "uroborosql-fmt.show-output";
 
   return statusBar;
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { workspace, ExtensionContext, window, commands } from "vscode";
+import { workspace, ExtensionContext, window, commands, StatusBarAlignment, ThemeColor, StatusBarItem } from "vscode";
 
 import {
   LanguageClient,
@@ -66,8 +66,51 @@ export function activate(context: ExtensionContext) {
     }),
   );
 
+
+
+  // ステータスバーの作成と表示
+  const statusBar = createStatusBar();
+  statusBar.show();
+
+  client.onReady().then(() => {
+    // ステータスバーの背景色を黄色に変更
+    client.onRequest("custom/warning", () => {
+      statusBar.backgroundColor = new ThemeColor(
+        "statusBarItem.warningBackground"
+      );
+    });
+
+    // ステータスバーの背景色を赤色に変更
+    client.onRequest("custom/error", () => {
+      statusBar.backgroundColor = new ThemeColor(
+        "statusBarItem.errorBackground"
+      );
+    })
+
+    // ステータスバーの背景色を通常色に変更
+    client.onRequest("custom/normal", () => {
+      statusBar.backgroundColor = new ThemeColor(
+        "statusBarItem.fourgroundBackground"
+      );
+    })
+  })
+
   // Start the client. This will also launch the server
   client.start();
+}
+
+function createStatusBar(): StatusBarItem {
+  commands.registerCommand("uroborosql-fmt.show-output", async () => {
+    const output_channnel = client.outputChannel;
+    output_channnel.show();
+  });
+
+  const statusBar = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+  statusBar.text = 'Uroborosql-fmt';
+  statusBar.name = 'Uroborosql-fmt';
+  statusBar.command = 'uroborosql-fmt.show-output'
+
+  return statusBar;
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -210,8 +210,12 @@ async function formatText(
 
     try {
       formattedText = runfmt(text, configPath);
+      // ステータスバーの背景を通常色に変更
+      connection.sendRequest("custom/normal", []);
     } catch (e) {
       console.error(e);
+      // ステータスバーの背景を赤色に変更
+      connection.sendRequest("custom/error", []);
       return [];
     }
 
@@ -227,11 +231,12 @@ async function formatText(
     const startTime = performance.now();
     try {
       formattedText = runfmt(text, configPath);
+      // ステータスバーの背景を通常色に変更
+      connection.sendRequest("custom/normal", []);
     } catch (e) {
       console.error(e);
-      connection.window.showErrorMessage(
-        `Formatter error. src:${textDocument.uri}, config:${configPath} msg: ${e}`,
-      );
+      // ステータスバーの背景を赤色に変更
+      connection.sendRequest("custom/error", []);
       return [];
     }
     //タイマーストップ


### PR DESCRIPTION
- ステータスバーにアイコンを追加
- アイコンを押下するとUroborosql-fmtのOutputに移動
- フォーマットエラー時に通知を出すのではなく、アイコンを赤色に変更することで通知するように変更

![image](https://github.com/future-architect/vscode-uroborosql-fmt/assets/52311998/6163ba96-1347-4b2c-b774-27e6b06942e6)

close #51 