### PR TITLE
fix: macos runner image

### DIFF
--- a/.changeset/eighty-pets-flash.md
+++ b/.changeset/eighty-pets-flash.md
@@ -1,0 +1,5 @@
+---
+"uroborosql-fmt": patch
+---
+
+Fixed formatting error on mac os (intel)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           #   platform: alpine
           #   arch: x64
           #   npm_config_arch: x64
-          - os: macos-latest
+          - os: macos-13
             platform: darwin
             arch: x64
             npm_config_arch: x64

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,7 +21,7 @@
     "node_modules/uroborosql-fmt-napi": {
       "version": "0.0.0",
       "resolved": "file:uroborosql-fmt-napi-0.0.0.tgz",
-      "integrity": "sha512-fPKOa1SK1Flm2QFb4U1BhyDwUWy0A6lRGQXmPx8VA1XNf57/jojMfnNHKuj3Wo+xOU3JYRNTFIpYcZzNFMcmoQ==",
+      "integrity": "sha512-nx47epBvAP4CZqxVImp4FQUqvz69fkUkmYdhC+TySvWfRRWBh2SwR0xtnEuSufpWRT+mGsuB2GMemlTc7ABvIA==",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">= 10"


### PR DESCRIPTION
mac(intel版)での不具合対応で以下の修正を行いました。

1. uroborosql-fmt-napi の更新
2. runner image を macos-13 に変更

ご確認お願いします 
@ota-meshi 