### PR TITLE
Pin changesets/action to v1.4.10 due to v1.5.0 tag push regression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,10 @@ jobs:
 
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@v1
+        # v1.5.0 以降、custom release スクリプトを使っているケースでローカル tag が作成されなくなった
+        # 当座の回避策として v1.4.10 に固定する
+        # ref: https://github.com/changesets/action/issues/465
+        uses: changesets/action@v1.4.10
         with:
           publish: npm run dummy-release
         env:


### PR DESCRIPTION
 changesets/action v1.5.0 以降、custom release スクリプトを使っているケースでローカル tag が作成されなくなった
当座の回避策として v1.4.10 に固定する
refs: https://github.com/changesets/action/issues/465

https://github.com/changesets/action/releases/tag/v1.4.10