### PR TITLE
feat: uroborosql-fmt NAPI バージョンの自動更新

### DIFF
--- a/.github/workflows/update-napi-version.yml
+++ b/.github/workflows/update-napi-version.yml
@@ -1,0 +1,71 @@
+name: Update NAPI Version
+
+on:
+  # 毎日 UTC 0:00 に uroborosql-fmt の最新リリースを確認
+  schedule:
+    - cron: "0 0 * * *"
+  # 手動実行も可能
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+    # fork からの実行を防止
+    if: github.repository == 'future-architect/vscode-uroborosql-fmt'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest uroborosql-fmt release version
+        id: latest
+        run: |
+          LATEST=$(curl -s https://api.github.com/repos/future-architect/uroborosql-fmt/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Latest uroborosql-fmt version: $LATEST"
+
+      - name: Get current NAPI version
+        id: current
+        run: |
+          CURRENT=$(grep -oP 'NAPI_VERSION = "\K[0-9]+\.[0-9]+\.[0-9]+' server/download-uroborosql-fmt-napi.mjs)
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "Current NAPI version: $CURRENT"
+
+      - name: Update version references
+        if: steps.latest.outputs.version != steps.current.outputs.version && steps.latest.outputs.version != 'null'
+        env:
+          NEW_VERSION: ${{ steps.latest.outputs.version }}
+          OLD_VERSION: ${{ steps.current.outputs.version }}
+        run: |
+          echo "Updating NAPI version from ${OLD_VERSION} to ${NEW_VERSION}"
+
+          # server/download-uroborosql-fmt-napi.mjs の NAPI_VERSION 定数を更新
+          sed -i "s/NAPI_VERSION = \"${OLD_VERSION}\"/NAPI_VERSION = \"${NEW_VERSION}\"/" server/download-uroborosql-fmt-napi.mjs
+
+          # server/package.json の依存関係パスを更新
+          sed -i "s/uroborosql-fmt-napi-${OLD_VERSION}/uroborosql-fmt-napi-${NEW_VERSION}/g" server/package.json
+
+          echo "Updated files:"
+          git diff --stat
+
+      - name: Create Pull Request
+        if: steps.latest.outputs.version != steps.current.outputs.version && steps.latest.outputs.version != 'null'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update uroborosql-fmt-napi to ${{ steps.latest.outputs.version }}"
+          title: "Update uroborosql-fmt-napi to ${{ steps.latest.outputs.version }}"
+          body: |
+            uroborosql-fmt-napi を ${{ steps.current.outputs.version }} から ${{ steps.latest.outputs.version }} に更新する自動 PR です。
+
+            Release: https://github.com/future-architect/uroborosql-fmt/releases/tag/v${{ steps.latest.outputs.version }}
+
+            > [!NOTE]
+            > vscode 拡張のリリースが必要な場合は、マージ前に changeset を追加してください。
+            > ```bash
+            > npx changeset
+            > ```
+          branch: update-napi-${{ steps.latest.outputs.version }}
+          delete-branch: true

--- a/server/download-uroborosql-fmt-napi.mjs
+++ b/server/download-uroborosql-fmt-napi.mjs
@@ -7,15 +7,20 @@ import * as cp from "child_process";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// uroborosql-fmt-napi のバージョン
+// update-napi-version.yml ワークフローによって自動更新される
+const NAPI_VERSION = "1.0.1";
+
 main();
 
 async function main() {
+  const tgzName = `uroborosql-fmt-napi-${NAPI_VERSION}.tgz`;
   const agent = autoProxyAgent();
   const res = await fetch(
-    "https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-1.0.1.tgz",
+    `https://github.com/future-architect/uroborosql-fmt/releases/download/v${NAPI_VERSION}/${tgzName}`,
     agent ? { dispatcher: agent } : undefined,
   );
-  const destination = join(__dirname, "uroborosql-fmt-napi-1.0.1.tgz");
+  const destination = join(__dirname, tgzName);
   writeFileSync(destination, Buffer.from(await res.arrayBuffer()));
 
   cp.execSync(`npm install ${destination}`, { cwd: __dirname });


### PR DESCRIPTION
## 概要

uroborosql-fmt リポジトリが release-plz によるバージョン管理に移行したことに伴い、NAPI バイナリの取得先を GitHub Pages から **GitHub Releases** に変更し、バージョン更新を自動化する。

関連: https://github.com/future-architect/uroborosql-fmt/pull/233

## 変更内容

### 1. NAPI ダウンロード URL の変更

```javascript
// Before (GitHub Pages — 新バージョンで上書きされ旧版が消える)
"https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-1.0.1.tgz"

// After (GitHub Releases — バージョンごとに残る)
`https://github.com/future-architect/uroborosql-fmt/releases/download/v${NAPI_VERSION}/${tgzName}`
```

- バージョンを `NAPI_VERSION` 定数に抽出（sed での置換を安全にするため）

### 2. バージョン自動更新ワークフロー

`.github/workflows/update-napi-version.yml`:
- 毎日 UTC 0:00 に uroborosql-fmt の最新リリースをチェック
- 新バージョンを検知したら自動 PR を作成
- 更新対象: `server/download-uroborosql-fmt-napi.mjs` と `server/package.json`
- 手動実行 (`workflow_dispatch`) も可能
- トークンはデフォルトの `GITHUB_TOKEN` を使用。`GITHUB_TOKEN` で作成した PR は GitHub のループ防止仕様により CI が自動実行されないが、バージョン番号の変更のみの PR なので手動 Re-run で十分と判断した。CI を自動実行したい場合は PAT に変更する。

## NAPI バージョン更新時の運用フロー

```
1. uroborosql-fmt で新バージョン (例: v1.0.2) がリリースされる

2. update-napi-version.yml が検知し、自動 PR を作成
   ブランチ: update-napi-1.0.2
   変更内容: NAPI_VERSION 定数と server/package.json のバージョン番号のみ

3. 開発者が uroborosql-fmt のリリース内容を確認し、vscode 拡張のリリースが必要か判断
   - リリース不要 → そのままマージ（次回リリースに含まれる）
   - リリースする → 4 へ

4. 自動 PR のブランチにチェックアウトして changeset を追加
   $ git checkout update-napi-1.0.2
   $ npx changeset
     → patch / minor / major を選択（コアの変更内容に応じて判断）
     → リリースノートの文言を記入
   $ git add .changeset/
   $ git commit -m "chore: add changeset"
   $ git push

5. PR をマージ

6. changesets が Release PR を自動作成（バージョン更新 + CHANGELOG 生成）

7. Release PR をマージ → VS Code Marketplace に自動公開
```

## マージ後に必要な手動作業

- Workflow permissions が「Read and write permissions」であることを確認
  - Settings → Actions → General → Workflow permissions

## 検討事項

- **自動 PR を automerge にするか** — しない。uroborosql-fmt はフォーマットのコアエンジンであり、変更がユーザー体験に直結する。CI (lint + compile) だけではフォーマット結果の妥当性は検証できないため、マージは手動で判断する。自動 PR は「新バージョンが出た」ことへの通知として機能すれば十分。
- **自動 PR に changeset を自動追加するか** — しない。changeset の内容（patch / minor / major、リリースノートの文言）はコアの変更内容に依存するため、手動で判断して追加する。

## 変更ファイル

| ファイル | 操作 |
|---|---|
| `server/download-uroborosql-fmt-napi.mjs` | 修正: URL 変更、`NAPI_VERSION` 定数化 |
| `.github/workflows/update-napi-version.yml` | **新規**: バージョン自動更新ワークフロー |
