### PR TITLE
feat: automate napi updates from GitHub Releases

### DIFF
--- a/.github/workflows/update-napi-version.yml
+++ b/.github/workflows/update-napi-version.yml
@@ -1,0 +1,84 @@
+name: Update NAPI Version
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+    if: github.repository == 'future-architect/vscode-uroborosql-fmt'
+    env:
+      NAPI_RELEASE_TAG_PREFIX: uroborosql-fmt-napi-v
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Get latest uroborosql-fmt NAPI release version
+        id: latest
+        run: |
+          TAG=$(curl -fsSL \
+            https://api.github.com/repos/future-architect/uroborosql-fmt/releases \
+            | jq -r --arg prefix "$NAPI_RELEASE_TAG_PREFIX" '
+                map(select(.tag_name | startswith($prefix)))[0].tag_name // "null"
+              ')
+          VERSION=$(printf '%s' "$TAG" | sed "s/^${NAPI_RELEASE_TAG_PREFIX}//")
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest uroborosql-fmt NAPI release tag: $TAG"
+          echo "Latest uroborosql-fmt NAPI version: $VERSION"
+
+      - name: Get current NAPI version
+        id: current
+        run: |
+          CURRENT=$(grep -oP 'NAPI_VERSION = "\K[0-9]+\.[0-9]+\.[0-9]+' server/download-uroborosql-fmt-napi.mjs)
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "Current NAPI version: $CURRENT"
+
+      - name: Update version references
+        if: steps.latest.outputs.version != steps.current.outputs.version && steps.latest.outputs.version != 'null'
+        env:
+          NEW_VERSION: ${{ steps.latest.outputs.version }}
+          OLD_VERSION: ${{ steps.current.outputs.version }}
+        run: |
+          echo "Updating NAPI version from ${OLD_VERSION} to ${NEW_VERSION}"
+
+          sed -i "s/NAPI_VERSION = \"${OLD_VERSION}\"/NAPI_VERSION = \"${NEW_VERSION}\"/" server/download-uroborosql-fmt-napi.mjs
+          sed -i "s/uroborosql-fmt-napi-${OLD_VERSION}/uroborosql-fmt-napi-${NEW_VERSION}/g" server/package.json
+
+          curl -fsSL \
+            -o "server/uroborosql-fmt-napi-${NEW_VERSION}.tgz" \
+            "https://github.com/future-architect/uroborosql-fmt/releases/download/uroborosql-fmt-napi-v${NEW_VERSION}/uroborosql-fmt-napi-${NEW_VERSION}.tgz"
+          (
+            cd server
+            npm install --package-lock-only "./uroborosql-fmt-napi-${NEW_VERSION}.tgz"
+            rm "./uroborosql-fmt-napi-${NEW_VERSION}.tgz"
+          )
+
+          echo "Updated files:"
+          git diff --stat
+
+      - name: Create Pull Request
+        if: steps.latest.outputs.version != steps.current.outputs.version && steps.latest.outputs.version != 'null'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update uroborosql-fmt-napi to ${{ steps.latest.outputs.version }}"
+          title: "Update uroborosql-fmt-napi to ${{ steps.latest.outputs.version }}"
+          body: |
+            uroborosql-fmt-napi を ${{ steps.current.outputs.version }} から ${{ steps.latest.outputs.version }} に更新する自動 PR です。
+
+            Release: https://github.com/future-architect/uroborosql-fmt/releases/tag/${{ steps.latest.outputs.tag }}
+
+            > [!NOTE]
+            > vscode 拡張のリリースが必要な場合は、マージ前に changeset を追加してください。
+            > ```bash
+            > npx changeset
+            > ```
+          branch: update-napi-${{ steps.latest.outputs.version }}
+          delete-branch: true

--- a/.github/workflows/update-napi-version.yml
+++ b/.github/workflows/update-napi-version.yml
@@ -80,6 +80,10 @@ jobs:
 
       - name: Create Pull Request
         if: steps.latest.outputs.version != steps.current.outputs.version && steps.latest.outputs.version != 'null'
+        # デフォルトの GITHUB_TOKEN で作成した PR は、GitHub のループ防止仕様により
+        # pull_request トリガーの workflow が自動実行されない。
+        # バージョン更新のみの PR のため手動確認・手動マージ前提で許容している。
+        # 自動実行したい場合は PAT など別トークンの利用を検討する。
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-napi-version.yml
+++ b/.github/workflows/update-napi-version.yml
@@ -40,6 +40,21 @@ jobs:
           echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "Current NAPI version: $CURRENT"
 
+      - name: Verify current version references are in sync
+        env:
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
+        run: |
+          PACKAGE_VERSION=$(grep -oP 'uroborosql-fmt-napi-\K[0-9]+\.[0-9]+\.[0-9]+' server/package.json)
+
+          if [ "$CURRENT_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Version mismatch detected:"
+            echo "  download-uroborosql-fmt-napi.mjs: $CURRENT_VERSION"
+            echo "  server/package.json: $PACKAGE_VERSION"
+            exit 1
+          fi
+
+          echo "Current version references are in sync: $CURRENT_VERSION"
+
       - name: Update version references
         if: steps.latest.outputs.version != steps.current.outputs.version && steps.latest.outputs.version != 'null'
         env:

--- a/server/download-uroborosql-fmt-napi.mjs
+++ b/server/download-uroborosql-fmt-napi.mjs
@@ -7,15 +7,21 @@ import * as cp from "child_process";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// uroborosql-fmt-napi のバージョン
+// update-napi-version.yml ワークフローによって自動更新される
+const NAPI_VERSION = "1.0.1";
+
 main();
 
 async function main() {
+  const tgzName = `uroborosql-fmt-napi-${NAPI_VERSION}.tgz`;
+  const releaseTag = `uroborosql-fmt-napi-v${NAPI_VERSION}`;
   const agent = autoProxyAgent();
   const res = await fetch(
-    "https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-1.0.1.tgz",
+    `https://github.com/future-architect/uroborosql-fmt/releases/download/${releaseTag}/${tgzName}`,
     agent ? { dispatcher: agent } : undefined,
   );
-  const destination = join(__dirname, "uroborosql-fmt-napi-1.0.1.tgz");
+  const destination = join(__dirname, tgzName);
   writeFileSync(destination, Buffer.from(await res.arrayBuffer()));
 
   cp.execSync(`npm install ${destination}`, { cwd: __dirname });

--- a/server/download-uroborosql-fmt-napi.mjs
+++ b/server/download-uroborosql-fmt-napi.mjs
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 // uroborosql-fmt-napi のバージョン
 // update-napi-version.yml ワークフローによって自動更新される
-const NAPI_VERSION = "1.0.1";
+const NAPI_VERSION = "1.0.2";
 
 main();
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BUSL-1.1",
       "dependencies": {
-        "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.0.1.tgz",
+        "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.0.2.tgz",
         "vscode-languageserver": "^9.0.0",
         "vscode-languageserver-textdocument": "^1.0.4",
         "vscode-uri": "^3.0.7"
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/uroborosql-fmt-napi": {
-      "version": "1.0.1",
-      "resolved": "file:uroborosql-fmt-napi-1.0.1.tgz",
-      "integrity": "sha512-oFstTpJMCoseiu/EoXUZL8z9ybKkgGdpkOk+bQW6zysBcPOp3t2J4OQl02iTg4axhQfYNYCNFKqULS0bIwPvYQ==",
+      "version": "1.0.2",
+      "resolved": "file:uroborosql-fmt-napi-1.0.2.tgz",
+      "integrity": "sha512-e/g9Q41ujpva+plZYttppLrPGdWYQ6JIXZdgjhboFXdlSntHK8Zyr2sCAa0kNet4igyYDC7sj6p99Cr3O5kijA==",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">= 10"

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {},
   "dependencies": {
-    "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.0.1.tgz",
+    "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.0.2.tgz",
     "vscode-languageserver": "^9.0.0",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-uri": "^3.0.7"


### PR DESCRIPTION
## 概要

`uroborosql-fmt-napi` の取得元を GitHub Releases ベースに整理し、`uroborosql-fmt` 側の component 付き release tag を使って NAPI version を自動追従する workflow を追加する。

あわせて、現在公開されている `uroborosql-fmt-napi-v1.0.2` を baseline として `server` 側の参照先を更新する。

関連:
- #103: release-plz 前提時の移行 PR
- `uroborosql-fmt` 側の release automation PR: https://github.com/future-architect/uroborosql-fmt/pull/249

## 変更内容

### 1. NAPI ダウンロード URL の整理

```javascript
// Before
"https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-1.0.1.tgz"

// After
`https://github.com/future-architect/uroborosql-fmt/releases/download/uroborosql-fmt-napi-v${NAPI_VERSION}/uroborosql-fmt-napi-${NAPI_VERSION}.tgz`
```

- `server/download-uroborosql-fmt-napi.mjs` に `NAPI_VERSION` を持たせる
- tgz のファイル名と component 付き release tag を `NAPI_VERSION` から組み立てる
- GitHub Pages の固定 URL ではなく、GitHub Releases の tag ベースで取得する

### 2. NAPI version 自動更新 workflow の追加

`.github/workflows/update-napi-version.yml`:
- 毎日 UTC 0:00 に `uroborosql-fmt` の release 一覧をチェック
- `uroborosql-fmt-napi-v*` 形式の tag に一致した最新 release を対象にする
- 新 version を検知したら自動 PR を作成する
- 更新対象は `server/download-uroborosql-fmt-napi.mjs`, `server/package.json`, `server/package-lock.json`
- `server/download-uroborosql-fmt-napi.mjs` と `server/package.json` の current version がずれていた場合は fail-fast で job を止める
- workflow 内で tgz をダウンロードし、`npm install --package-lock-only` で `server/package-lock.json` を同期する
- トークンはデフォルトの `GITHUB_TOKEN` を使用する

### 3. baseline を `1.0.2` に更新

- `uroborosql-fmt-napi-v1.0.2` が公開済みのため、PR 作成時点の `1.0.1` 参照を `1.0.2` に更新した
- これにより、component 付き release tag 形式へ切り替えた状態でも fresh install が成立する

## 既知の制約

- release 取得は GitHub Releases API の先頭ページだけを見ている
  - release 件数が増えて NAPI release が先頭ページから外れた場合は、別途取得方法の見直しが必要
- `uroborosql-fmt-napi-v*` に一致する prerelease は現状除外していない
  - prerelease を publish する運用に変わる場合は、stable のみを取る条件追加を検討する

## NAPI version 更新時の運用フロー

1. `uroborosql-fmt-napi` の新しい release が作成される

2. `update-napi-version.yml` が新しい version を検知し、自動 PR を作成する
   - 変更内容: `NAPI_VERSION` / `server/package.json` / `server/package-lock.json` の更新
   - ブランチ名: `update-napi-x.y.z`

3. 開発者が `vscode` 拡張の release 要否を判断する
   - release 不要: そのままマージ
   - release する: 4. へ進む

4. 必要なら `changeset` を手動で追加する
   - `npx changeset`

5. PR をマージする

6. 既存の Changesets フローが release PR を作成する

7. 既存フローの release PR をマージして publish する

## マージ後に必要な手動作業

- Workflow permissions が `Read and write permissions` であることを確認する
  - Settings -> Actions -> General -> Workflow permissions

## 検討事項

- 自動 PR に `changeset` は自動追加しない
  - `vscode-uroborosql-fmt` を release するかどうかは、人が判断する
- 自動 PR の役割は依存更新の追従に限定する
  - `changeset` が必要な場合だけ手動で追加する

## 変更ファイル

| ファイル | 操作 |
|---|---|
| `server/download-uroborosql-fmt-napi.mjs` | 修正: component 付き release tag ベースの URL に変更、version 定数化、baseline を `1.0.2` に更新 |
| `server/package.json` | 修正: `uroborosql-fmt-napi` の参照先を `1.0.2` に更新 |
| `server/package-lock.json` | 修正: `uroborosql-fmt-napi` の lockfile を `1.0.2` に同期 |
| `.github/workflows/update-napi-version.yml` | 新規: NAPI version 自動更新 workflow、current version の整合チェックを追加 |
