### PR TITLE
chore: pin Node.js version to 24 and fix napi download script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
       - name: Install Packages
         run: npm ci
       - name: Lint
@@ -21,6 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
       - name: Install Packages
         run: npm ci
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
       - run: |
           npm install
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/update-napi-version.yml
+++ b/.github/workflows/update-napi-version.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+
       - name: Get latest uroborosql-fmt NAPI release version
         id: latest
         run: |

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "@vscode/test-electron": "^2.1.2"
       },
       "engines": {
+        "node": ">=24.14.0 <25",
         "vscode": "^1.63.0"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
   "publisher": "Future",
   "repository": {},
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.63.0",
+    "node": ">=24.14.0 <25"
   },
   "dependencies": {
     "vscode-languageclient": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,10 @@
         "eslint": "^8.50.0",
         "mocha": "^11.0.0",
         "prettier": "~3.9.0",
-        "typescript": "^5.2.2",
-        "undici": "^8.0.0"
+        "typescript": "^5.2.2"
       },
       "engines": {
+        "node": ">=24.14.0 <25",
         "vscode": "^1.63.0"
       }
     },
@@ -5466,16 +5466,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.0.tgz",
-      "integrity": "sha512-RGabV5g1ggSX5mU4k+B8BLWgb418gDbg0wAVFeiU00iOxtw4ufGsE6GFsuSd2uqOKooWSLf71JGapOFYpE8f+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "formatter"
   ],
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.63.0",
+    "node": ">=24.14.0 <25"
   },
   "activationEvents": [
     "*"
@@ -284,7 +285,6 @@
     "eslint": "^8.50.0",
     "mocha": "^11.0.0",
     "prettier": "~3.9.0",
-    "typescript": "^5.2.2",
-    "undici": "^8.0.0"
+    "typescript": "^5.2.2"
   }
 }

--- a/server/download-uroborosql-fmt-napi.mjs
+++ b/server/download-uroborosql-fmt-napi.mjs
@@ -1,8 +1,8 @@
 import { writeFileSync } from "node:fs";
+import http from "node:http";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { ProxyAgent } from "undici";
-import * as cp from "child_process";
+import { execSync } from "node:child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,45 +11,26 @@ const __dirname = dirname(__filename);
 // update-napi-version.yml ワークフローによって自動更新される
 const NAPI_VERSION = "1.1.0";
 
+const releaseTag = `uroborosql-fmt-napi-v${NAPI_VERSION}`;
+const tgzName = `uroborosql-fmt-napi-${NAPI_VERSION}.tgz`;
+const tarballUrl = `https://github.com/future-architect/uroborosql-fmt/releases/download/${releaseTag}/${tgzName}`;
+
+http.setGlobalProxyFromEnv();
+
 main();
 
 async function main() {
-  const tgzName = `uroborosql-fmt-napi-${NAPI_VERSION}.tgz`;
-  const releaseTag = `uroborosql-fmt-napi-v${NAPI_VERSION}`;
-  const agent = autoProxyAgent();
-  const res = await fetch(
-    `https://github.com/future-architect/uroborosql-fmt/releases/download/${releaseTag}/${tgzName}`,
-    agent ? { dispatcher: agent } : undefined,
-  );
-  const destination = join(__dirname, tgzName);
-  writeFileSync(destination, Buffer.from(await res.arrayBuffer()));
+  console.log(`Downloading and installing from: ${tarballUrl}`);
 
-  cp.execSync(`npm install ${destination}`, { cwd: __dirname });
-}
-
-function autoProxyAgent() {
-  const PROXY_ENV = [
-    "https_proxy",
-    "HTTPS_PROXY",
-    "http_proxy",
-    "HTTP_PROXY",
-    "npm_config_https_proxy",
-    "npm_config_http_proxy",
-  ];
-
-  const proxyStr = PROXY_ENV.map((k) => process.env[k]).find((v) => v);
-  if (!proxyStr) {
-    return null;
+  const response = await fetch(tarballUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${tarballUrl}: ${response.status} ${response.statusText}`,
+    );
   }
-  const proxyUrl = new URL(proxyStr);
 
-  return new ProxyAgent({
-    uri: proxyUrl.protocol + proxyUrl.host,
-    token:
-      proxyUrl.username || proxyUrl.password
-        ? `Basic ${Buffer.from(
-            `${proxyUrl.username}:${decodeURIComponent(proxyUrl.password)}`,
-          ).toString("base64")}`
-        : undefined,
-  });
+  const destination = join(__dirname, tgzName);
+  writeFileSync(destination, Buffer.from(await response.arrayBuffer()));
+
+  execSync(`npm install ${destination}`, { cwd: __dirname, stdio: "inherit" });
 }

--- a/server/download-uroborosql-fmt-napi.mjs
+++ b/server/download-uroborosql-fmt-napi.mjs
@@ -15,7 +15,23 @@ const releaseTag = `uroborosql-fmt-napi-v${NAPI_VERSION}`;
 const tgzName = `uroborosql-fmt-napi-${NAPI_VERSION}.tgz`;
 const tarballUrl = `https://github.com/future-architect/uroborosql-fmt/releases/download/${releaseTag}/${tgzName}`;
 
-http.setGlobalProxyFromEnv();
+const proxyEnv = {
+  ...process.env,
+  HTTP_PROXY:
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy ??
+    process.env.npm_config_http_proxy,
+  HTTPS_PROXY:
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.npm_config_https_proxy,
+  NO_PROXY:
+    process.env.NO_PROXY ??
+    process.env.no_proxy ??
+    process.env.npm_config_no_proxy,
+};
+
+http.setGlobalProxyFromEnv(proxyEnv);
 
 main();
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,7 @@
         "vscode-uri": "^3.0.7"
       },
       "engines": {
-        "node": "*"
+        "node": ">=24.14.0 <25"
       }
     },
     "node_modules/uroborosql-fmt-napi": {

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "publisher": "Future",
   "license": "BUSL-1.1",
   "engines": {
-    "node": "*"
+    "node": ">=24.14.0 <25"
   },
   "repository": {},
   "dependencies": {


### PR DESCRIPTION
## Summary

Node.js のバージョンを明示的に指定しました。

あわせて、napi ダウンロードスクリプト（`server/download-uroborosql-fmt-napi.mjs`）を修正しました。

## Changes

### 1. Node.js バージョンの指定

- `engines.node` を `">=24.14.0 <25"` に設定
  - root `package.json`: `engines` に `"node": ">=24.14.0 <25"` を追加
  - `client/package.json`: `engines` に `"node": ">=24.14.0 <25"` を追加
  - `server/package.json`: `engines.node` を `"*"` から `">=24.14.0 <25"` へ変更
- `actions/setup-node` に `node-version-file: package.json` と `cache: npm` を付与
  - `ci.yml` / `release.yml` / `publish.yml`: 既存の `setup-node@v4` に付与
  - `update-napi-version.yml`: `setup-node` を **新規追加**（後述）
- 上記 `engines` 変更を各 `package-lock.json`（root / client / server）に反映

### 2. napi ダウンロードスクリプトの修正

Node.js バージョンの指定に伴いダウンロードスクリプトが壊れたため修正しました。

原因は、node.js の更新に伴い fetch のの挙動が代わり、従来の`undici` 依存の実装が噛み合わなくなったためです。
`unidici` が提供する fetch を利用することでも解決できますが、今回は `undici` を撤廃し、Node.js 24 系の標準 `fetch` と組み込みのプロキシ設定を使う形としました
そのうえで、従来どおりローカル tarball を保存してから `npm install` する流れは維持しています。

- `server/download-uroborosql-fmt-napi.mjs`
  - `ProxyAgent` を撤廃しました
  - `http.setGlobalProxyFromEnv()` を追加し、標準の`fetch` でもプロキシ経由でダウンロードできるようにしました
  - この機能を使うために **Node.js `v24.14.0` 以降** を指定しています
- `package.json` / `package-lock.json`（root）: devDependencies から `undici` を撤廃

## Notes
- Node.js バージョンは `"24"` ではなく `">=24.14.0 <25"` を指定
  - Node.js fetch のプロキシ機能 `http.setGlobalProxyFromEnv()` を利用するため下限を `24.14.0` としています
  - 24 系に閉じるため、25 は含めていません
- `update-napi-version.yml` にも `setup-node` を新規追加
  - このワークフローは `npm install --package-lock-only` で `server/package-lock.json` を更新します。現状はシステムの node / npm を利用していますが、動作を統一するため setup-node action を追加しました。
  - バージョンは他の 3 ファイルと揃えて `actions/setup-node@v4` としています。action の sha pinning と最新化（v6 化）は別 PR でまとめて行います。
