### PR TITLE
fix(extension): surface formatting failures in status bar

### DIFF
--- a/client/src/command.ts
+++ b/client/src/command.ts
@@ -15,6 +15,7 @@ import {
   WorkspaceEdit,
 } from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
+import type { StatusBarController } from "./status";
 
 const FORMAT_SELECTIONS_AS_SQL_METHOD = "uroborosql/formatSelectionsAsSql";
 const EMPTY_SELECTION_MESSAGE = "Select text to format as SQL.";
@@ -341,7 +342,11 @@ const hasOverlappingSelections = (
 };
 
 const buildFormatAsSqlCommand =
-  (client: LanguageClient, options: FormatAsSqlCommandOptions) =>
+  (
+    client: LanguageClient,
+    statusBar: Pick<StatusBarController, "showNormal" | "showError">,
+    options: FormatAsSqlCommandOptions,
+  ) =>
   async (): Promise<void> => {
     const editor = window.activeTextEditor;
     if (!editor) {
@@ -407,17 +412,25 @@ const buildFormatAsSqlCommand =
       }
 
       await workspace.applyEdit(edit);
+      statusBar.showNormal();
     } catch (error) {
       window.showErrorMessage(formatFailureMessage(error));
+      statusBar.showError();
     }
   };
 
-export const buildFormatSelectionsAsSqlCommand = (client: LanguageClient) =>
-  buildFormatAsSqlCommand(client, {
+export const buildFormatSelectionsAsSqlCommand = (
+  client: LanguageClient,
+  statusBar: Pick<StatusBarController, "showNormal" | "showError">,
+) =>
+  buildFormatAsSqlCommand(client, statusBar, {
     formatWholeDocumentWhenNoSelection: false,
   });
 
-export const buildFormatSqlCommand = (client: LanguageClient) =>
-  buildFormatAsSqlCommand(client, {
+export const buildFormatSqlCommand = (
+  client: LanguageClient,
+  statusBar: Pick<StatusBarController, "showNormal" | "showError">,
+) =>
+  buildFormatAsSqlCommand(client, statusBar, {
     formatWholeDocumentWhenNoSelection: true,
   });

--- a/client/src/command.ts
+++ b/client/src/command.ts
@@ -411,7 +411,13 @@ const buildFormatAsSqlCommand =
         );
       }
 
-      await workspace.applyEdit(edit);
+      // applyEdit は文書がリクエスト後に変化した場合などに false を返すため、
+      // version mismatch と同じ「サーバ失敗ではない適用中断」として扱い status は変えない
+      const applied = await workspace.applyEdit(edit);
+      if (!applied) {
+        window.showErrorMessage(VERSION_MISMATCH_MESSAGE);
+        return;
+      }
       statusBar.showNormal();
     } catch (error) {
       window.showErrorMessage(formatFailureMessage(error));

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,16 +1,10 @@
 import * as path from "path";
-import {
-  ExtensionContext,
-  window,
-  commands,
-  StatusBarAlignment,
-  StatusBarItem,
-  ConfigurationTarget,
-} from "vscode";
+import { ExtensionContext, commands, ConfigurationTarget } from "vscode";
 
 import {
   LanguageClient,
   LanguageClientOptions,
+  RevealOutputChannelOn,
   ServerOptions,
   TransportKind,
 } from "vscode-languageclient/node";
@@ -21,11 +15,19 @@ import {
   buildFormatSqlCommand,
   buildFormatSelectionsAsSqlCommand,
 } from "./command";
+import { withFormattingStatus } from "./formattingStatus";
+import { createStatusBarController, type StatusBarState } from "./status";
 
 let client: LanguageClient;
+let statusBarState: StatusBarState = "normal";
+
+type ExtensionApi = {
+  onReady(): Promise<void>;
+  getStatusState(): StatusBarState;
+};
 
 //拡張機能を立ち上げたときに呼び出す関数
-export function activate(context: ExtensionContext) {
+export function activate(context: ExtensionContext): ExtensionApi {
   // The server is implemented in node
   const serverModule = context.asAbsolutePath(
     path.join("server", "out", "server.js"),
@@ -36,11 +38,42 @@ export function activate(context: ExtensionContext) {
     debug: { module: serverModule, transport: TransportKind.stdio },
   };
 
+  const statusBar = createStatusBarController(() => {
+    client.outputChannel.show();
+  });
+  const showNormal = () => {
+    statusBar.showNormal();
+    statusBarState = statusBar.getState();
+  };
+  const showError = () => {
+    statusBar.showError();
+    statusBarState = statusBar.getState();
+  };
+
   const clientOptions: LanguageClientOptions = {
     // 拡張がサーバへ渡すのは SQL 文書のみに限定する。
     documentSelector: [{ scheme: "file", language: "sql" }],
     synchronize: {
       configurationSection: "uroborosql-fmt",
+    },
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
+    middleware: {
+      provideDocumentFormattingEdits: async (document, options, token, next) =>
+        withFormattingStatus(() => next(document, options, token), {
+          showNormal,
+          showError,
+        }),
+      provideDocumentRangeFormattingEdits: async (
+        document,
+        range,
+        options,
+        token,
+        next,
+      ) =>
+        withFormattingStatus(() => next(document, range, options, token), {
+          showNormal,
+          showError,
+        }),
     },
   };
 
@@ -55,14 +88,21 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand(
       "uroborosql-fmt.uroborosql-format",
-      buildFormatSqlCommand(client),
+      buildFormatSqlCommand(client, { showNormal, showError }),
     ),
   );
 
   context.subscriptions.push(
     commands.registerCommand(
       "uroborosql-fmt.format-selection-as-sql",
-      buildFormatSelectionsAsSqlCommand(client),
+      buildFormatSelectionsAsSqlCommand(client, { showNormal, showError }),
+    ),
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand(
+      "uroborosql-fmt.show-output",
+      statusBar.showOutput,
     ),
   );
 
@@ -84,28 +124,15 @@ export function activate(context: ExtensionContext) {
     ),
   );
 
-  // ステータスバーの作成と表示
-  const statusBar = createStatusBar();
-  statusBar.show();
+  context.subscriptions.push(statusBar);
 
   // Start the client. This will also launch the server
   client.start();
 
-  return { onReady: () => client.onReady() };
-}
-
-function createStatusBar(): StatusBarItem {
-  commands.registerCommand("uroborosql-fmt.show-output", async () => {
-    const output_channnel = client.outputChannel;
-    output_channnel.show();
-  });
-
-  const statusBar = window.createStatusBarItem(StatusBarAlignment.Right, 100);
-  statusBar.text = "Uroborosql-fmt";
-  statusBar.name = "Uroborosql-fmt";
-  statusBar.command = "uroborosql-fmt.show-output";
-
-  return statusBar;
+  return {
+    onReady: () => client.onReady(),
+    getStatusState: () => statusBarState,
+  };
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -19,7 +19,6 @@ import { withFormattingStatus } from "./formattingStatus";
 import { createStatusBarController, type StatusBarState } from "./status";
 
 let client: LanguageClient;
-let statusBarState: StatusBarState = "normal";
 
 type ExtensionApi = {
   onReady(): Promise<void>;
@@ -41,14 +40,6 @@ export function activate(context: ExtensionContext): ExtensionApi {
   const statusBar = createStatusBarController(() => {
     client.outputChannel.show();
   });
-  const showNormal = () => {
-    statusBar.showNormal();
-    statusBarState = statusBar.getState();
-  };
-  const showError = () => {
-    statusBar.showError();
-    statusBarState = statusBar.getState();
-  };
 
   const clientOptions: LanguageClientOptions = {
     // 拡張がサーバへ渡すのは SQL 文書のみに限定する。
@@ -59,10 +50,7 @@ export function activate(context: ExtensionContext): ExtensionApi {
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     middleware: {
       provideDocumentFormattingEdits: async (document, options, token, next) =>
-        withFormattingStatus(() => next(document, options, token), {
-          showNormal,
-          showError,
-        }),
+        withFormattingStatus(() => next(document, options, token), statusBar),
       provideDocumentRangeFormattingEdits: async (
         document,
         range,
@@ -70,10 +58,10 @@ export function activate(context: ExtensionContext): ExtensionApi {
         token,
         next,
       ) =>
-        withFormattingStatus(() => next(document, range, options, token), {
-          showNormal,
-          showError,
-        }),
+        withFormattingStatus(
+          () => next(document, range, options, token),
+          statusBar,
+        ),
     },
   };
 
@@ -88,14 +76,14 @@ export function activate(context: ExtensionContext): ExtensionApi {
   context.subscriptions.push(
     commands.registerCommand(
       "uroborosql-fmt.uroborosql-format",
-      buildFormatSqlCommand(client, { showNormal, showError }),
+      buildFormatSqlCommand(client, statusBar),
     ),
   );
 
   context.subscriptions.push(
     commands.registerCommand(
       "uroborosql-fmt.format-selection-as-sql",
-      buildFormatSelectionsAsSqlCommand(client, { showNormal, showError }),
+      buildFormatSelectionsAsSqlCommand(client, statusBar),
     ),
   );
 
@@ -131,7 +119,7 @@ export function activate(context: ExtensionContext): ExtensionApi {
 
   return {
     onReady: () => client.onReady(),
-    getStatusState: () => statusBarState,
+    getStatusState: () => statusBar.getState(),
   };
 }
 

--- a/client/src/formattingStatus.ts
+++ b/client/src/formattingStatus.ts
@@ -20,6 +20,6 @@ export async function withFormattingStatus<T>(
       throw error;
     }
     status.showError();
-    throw error;
+    return undefined;
   }
 }

--- a/client/src/formattingStatus.ts
+++ b/client/src/formattingStatus.ts
@@ -1,0 +1,25 @@
+type Awaitable<T> = T | PromiseLike<T>;
+
+export type FormattingStatusReporter = {
+  showNormal(): void;
+  showError(): void;
+};
+
+export async function withFormattingStatus<T>(
+  next: () => Awaitable<T | null | undefined>,
+  status: FormattingStatusReporter,
+): Promise<T | null | undefined> {
+  try {
+    const result = await Promise.resolve(next());
+    if (result != null) {
+      status.showNormal();
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof Error && error.name === "Canceled") {
+      throw error;
+    }
+    status.showError();
+    throw error;
+  }
+}

--- a/client/src/status.ts
+++ b/client/src/status.ts
@@ -1,0 +1,44 @@
+import { StatusBarAlignment, ThemeColor, window } from "vscode";
+
+export type StatusBarState = "normal" | "error";
+
+export type StatusBarController = {
+  showNormal(): void;
+  showError(): void;
+  showOutput(): void;
+  getState(): StatusBarState;
+  dispose(): void;
+};
+
+const NORMAL_TEXT = "Uroborosql-fmt";
+const ERROR_TEXT = "$(alert) Uroborosql-fmt";
+
+export function createStatusBarController(
+  showOutput: () => void,
+): StatusBarController {
+  const statusBar = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+  let state: StatusBarState = "normal";
+
+  statusBar.name = NORMAL_TEXT;
+  statusBar.command = "uroborosql-fmt.show-output";
+
+  const applyState = (nextState: StatusBarState) => {
+    state = nextState;
+    statusBar.text = nextState === "error" ? ERROR_TEXT : NORMAL_TEXT;
+    statusBar.backgroundColor =
+      nextState === "error"
+        ? new ThemeColor("statusBarItem.errorBackground")
+        : undefined;
+  };
+
+  applyState("normal");
+  statusBar.show();
+
+  return {
+    showNormal: () => applyState("normal"),
+    showError: () => applyState("error"),
+    showOutput,
+    getState: () => state,
+    dispose: () => statusBar.dispose(),
+  };
+}

--- a/client/src/test/formatSelectionAsSql.test.ts
+++ b/client/src/test/formatSelectionAsSql.test.ts
@@ -7,6 +7,7 @@ import {
   getDocUri,
   replaceDocumentText,
   waitForDocumentTextChange,
+  waitForStatusState,
 } from "./helper";
 
 suite("Should format SQL via commands", () => {
@@ -57,9 +58,11 @@ suite("Should format SQL via commands", () => {
       wholeDocumentAsSqlUri,
       original,
     );
+    const status = await waitForStatusState("normal");
 
     assert.notStrictEqual(formatted, original);
     assert.match(formatted, formattedEmbeddedSql);
+    assert.strictEqual(status, "normal");
   });
 
   test("Rejects overlapping selections before sending the request", async () => {
@@ -114,8 +117,10 @@ suite("Should format SQL via commands", () => {
     const latestDocument = await vscode.workspace.openTextDocument(
       invalidEmbeddedDocUri,
     );
+    const status = await waitForStatusState("error");
     assert.strictEqual(latestDocument.getText(), original);
     assert.strictEqual(messages.length, 1);
     assert.match(messages[0], /^Format failed: /);
+    assert.strictEqual(status, "error");
   });
 });

--- a/client/src/test/formatting.test.ts
+++ b/client/src/test/formatting.test.ts
@@ -4,10 +4,14 @@ import {
   activateAndOpen,
   getDocUri,
   waitForDocumentTextChange,
+  waitForStatusState,
 } from "./helper";
 
 suite("Should format SQL documents", () => {
   const docUri = getDocUri("format.sql");
+  const rangeUri = getDocUri("range.sql");
+  const originalFullDocument = "select A from B\n";
+  const originalRangeDocument = "select a from b;\n";
   const expectedFullDocument = ["select", "\ta\tas\ta", "from", "\tb", ""].join(
     "\n",
   );
@@ -20,18 +24,33 @@ suite("Should format SQL documents", () => {
     "",
   ].join("\n");
 
+  const resetFormattingFixtures = async (): Promise<void> => {
+    await vscode.workspace.fs.writeFile(
+      docUri,
+      Buffer.from(originalFullDocument),
+    );
+    await vscode.workspace.fs.writeFile(
+      rangeUri,
+      Buffer.from(originalRangeDocument),
+    );
+  };
+
+  setup(resetFormattingFixtures);
+  teardown(resetFormattingFixtures);
+
   test("Formats an entire SQL document", async () => {
     const document = await activateAndOpen(docUri);
     const original = document.getText();
     await vscode.commands.executeCommand("editor.action.formatDocument");
     const formatted = await waitForDocumentTextChange(docUri, original);
+    const status = await waitForStatusState("normal");
 
     assert.notStrictEqual(formatted, original);
     assert.strictEqual(formatted, expectedFullDocument);
+    assert.strictEqual(status, "normal");
   });
 
   test("Formats a selected SQL range", async () => {
-    const rangeUri = getDocUri("range.sql");
     const document = await activateAndOpen(rangeUri);
     const fullRange = new vscode.Range(
       document.positionAt(0),
@@ -45,8 +64,10 @@ suite("Should format SQL documents", () => {
 
     await vscode.commands.executeCommand("editor.action.formatSelection");
     const formatted = await waitForDocumentTextChange(rangeUri, original);
+    const status = await waitForStatusState("normal");
 
     assert.notStrictEqual(formatted, original);
     assert.strictEqual(formatted, expectedSelectedRange);
+    assert.strictEqual(status, "normal");
   });
 });

--- a/client/src/test/formatting.test.ts
+++ b/client/src/test/formatting.test.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import {
   activateAndOpen,
   getDocUri,
+  replaceDocumentText,
   waitForDocumentTextChange,
   waitForStatusState,
 } from "./helper";
@@ -23,6 +24,8 @@ suite("Should format SQL documents", () => {
     ";",
     "",
   ].join("\n");
+  const invalidFullDocument = "select from\n";
+  const invalidRangeDocument = "select from;\n";
 
   const resetFormattingFixtures = async (): Promise<void> => {
     await vscode.workspace.fs.writeFile(
@@ -38,6 +41,17 @@ suite("Should format SQL documents", () => {
   setup(resetFormattingFixtures);
   teardown(resetFormattingFixtures);
 
+  const selectFullDocument = (document: vscode.TextDocument) => {
+    const fullRange = new vscode.Range(
+      document.positionAt(0),
+      document.positionAt(document.getText().length),
+    );
+    vscode.window.activeTextEditor!.selection = new vscode.Selection(
+      fullRange.start,
+      fullRange.end,
+    );
+  };
+
   test("Formats an entire SQL document", async () => {
     const document = await activateAndOpen(docUri);
     const original = document.getText();
@@ -50,17 +64,36 @@ suite("Should format SQL documents", () => {
     assert.strictEqual(status, "normal");
   });
 
+  test("Marks status as error for document formatting failures and recovers on success", async () => {
+    const document = await activateAndOpen(docUri);
+    await replaceDocumentText(document, invalidFullDocument);
+    const invalidText = document.getText();
+
+    await vscode.commands.executeCommand("editor.action.formatDocument");
+    const errorStatus = await waitForStatusState("error");
+    const unchangedAfterFailure = document.getText();
+
+    assert.strictEqual(unchangedAfterFailure, invalidText);
+    assert.strictEqual(errorStatus, "error");
+
+    await replaceDocumentText(document, originalFullDocument);
+    const recoverySource = document.getText();
+
+    await vscode.commands.executeCommand("editor.action.formatDocument");
+    const recoveredText = await waitForDocumentTextChange(
+      docUri,
+      recoverySource,
+    );
+    const recoveredStatus = await waitForStatusState("normal");
+
+    assert.strictEqual(recoveredText, expectedFullDocument);
+    assert.strictEqual(recoveredStatus, "normal");
+  });
+
   test("Formats a selected SQL range", async () => {
     const document = await activateAndOpen(rangeUri);
-    const fullRange = new vscode.Range(
-      document.positionAt(0),
-      document.positionAt(document.getText().length),
-    );
     const original = document.getText();
-    vscode.window.activeTextEditor!.selection = new vscode.Selection(
-      fullRange.start,
-      fullRange.end,
-    );
+    selectFullDocument(document);
 
     await vscode.commands.executeCommand("editor.action.formatSelection");
     const formatted = await waitForDocumentTextChange(rangeUri, original);
@@ -69,5 +102,33 @@ suite("Should format SQL documents", () => {
     assert.notStrictEqual(formatted, original);
     assert.strictEqual(formatted, expectedSelectedRange);
     assert.strictEqual(status, "normal");
+  });
+
+  test("Marks status as error for range formatting failures and recovers on success", async () => {
+    const document = await activateAndOpen(rangeUri);
+    await replaceDocumentText(document, invalidRangeDocument);
+    selectFullDocument(document);
+    const invalidText = document.getText();
+
+    await vscode.commands.executeCommand("editor.action.formatSelection");
+    const errorStatus = await waitForStatusState("error");
+    const unchangedAfterFailure = document.getText();
+
+    assert.strictEqual(unchangedAfterFailure, invalidText);
+    assert.strictEqual(errorStatus, "error");
+
+    await replaceDocumentText(document, originalRangeDocument);
+    selectFullDocument(document);
+    const recoverySource = document.getText();
+
+    await vscode.commands.executeCommand("editor.action.formatSelection");
+    const recoveredText = await waitForDocumentTextChange(
+      rangeUri,
+      recoverySource,
+    );
+    const recoveredStatus = await waitForStatusState("normal");
+
+    assert.strictEqual(recoveredText, expectedSelectedRange);
+    assert.strictEqual(recoveredStatus, "normal");
   });
 });

--- a/client/src/test/formattingStatus.test.ts
+++ b/client/src/test/formattingStatus.test.ts
@@ -27,22 +27,20 @@ suite("Formatting status middleware", () => {
     assert.deepStrictEqual(calls, []);
   });
 
-  test("marks status as error when formatting throws", async () => {
+  test("marks status as error and suppresses formatting errors", async () => {
     const calls: string[] = [];
 
-    await assert.rejects(
-      withFormattingStatus(
-        async () => {
-          throw new Error("format failed");
-        },
-        {
-          showNormal: () => calls.push("normal"),
-          showError: () => calls.push("error"),
-        },
-      ),
-      /format failed/,
+    const result = await withFormattingStatus(
+      async () => {
+        throw new Error("format failed");
+      },
+      {
+        showNormal: () => calls.push("normal"),
+        showError: () => calls.push("error"),
+      },
     );
 
+    assert.strictEqual(result, undefined);
     assert.deepStrictEqual(calls, ["error"]);
   });
 

--- a/client/src/test/formattingStatus.test.ts
+++ b/client/src/test/formattingStatus.test.ts
@@ -1,0 +1,69 @@
+import * as assert from "assert";
+
+import { withFormattingStatus } from "../formattingStatus";
+
+suite("Formatting status middleware", () => {
+  test("marks status as normal when formatting returns edits", async () => {
+    const calls: string[] = [];
+
+    const result = await withFormattingStatus(async () => ["edit"], {
+      showNormal: () => calls.push("normal"),
+      showError: () => calls.push("error"),
+    });
+
+    assert.deepStrictEqual(result, ["edit"]);
+    assert.deepStrictEqual(calls, ["normal"]);
+  });
+
+  test("does not change status when formatting resolves to null", async () => {
+    const calls: string[] = [];
+
+    const result = await withFormattingStatus(async () => null, {
+      showNormal: () => calls.push("normal"),
+      showError: () => calls.push("error"),
+    });
+
+    assert.strictEqual(result, null);
+    assert.deepStrictEqual(calls, []);
+  });
+
+  test("marks status as error when formatting throws", async () => {
+    const calls: string[] = [];
+
+    await assert.rejects(
+      withFormattingStatus(
+        async () => {
+          throw new Error("format failed");
+        },
+        {
+          showNormal: () => calls.push("normal"),
+          showError: () => calls.push("error"),
+        },
+      ),
+      /format failed/,
+    );
+
+    assert.deepStrictEqual(calls, ["error"]);
+  });
+
+  test("ignores canceled requests", async () => {
+    const calls: string[] = [];
+    const error = new Error("canceled");
+    error.name = "Canceled";
+
+    await assert.rejects(
+      withFormattingStatus(
+        async () => {
+          throw error;
+        },
+        {
+          showNormal: () => calls.push("normal"),
+          showError: () => calls.push("error"),
+        },
+      ),
+      (thrown: unknown) => thrown === error,
+    );
+
+    assert.deepStrictEqual(calls, []);
+  });
+});

--- a/client/src/test/helper.ts
+++ b/client/src/test/helper.ts
@@ -4,7 +4,10 @@ import * as path from "path";
 const EXTENSION_ID = "Future.uroborosql-fmt";
 const DEFAULT_TIMEOUT_MS = 10_000;
 
-type ExtensionApi = { onReady(): Promise<void> };
+type ExtensionApi = {
+  onReady(): Promise<void>;
+  getStatusState(): "normal" | "error";
+};
 
 export async function activateExtension(): Promise<ExtensionApi> {
   const ext = vscode.extensions.getExtension<ExtensionApi>(EXTENSION_ID);
@@ -31,6 +34,24 @@ export async function waitForLanguageClientReady(
     api.onReady(),
     timeoutMs,
     "Timed out waiting for the language client to become ready",
+  );
+}
+
+export async function getStatusState(): Promise<"normal" | "error"> {
+  const api = await activateExtension();
+  return api.getStatusState();
+}
+
+export async function waitForStatusState(
+  expected: "normal" | "error",
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<"normal" | "error"> {
+  return waitFor(
+    () => getStatusState(),
+    (value) => value === expected,
+    timeoutMs,
+    50,
+    `Timed out waiting for status state ${expected}`,
   );
 }
 
@@ -307,4 +328,14 @@ export async function updateLintConfigurationFilePath(
   await vscode.workspace
     .getConfiguration("uroborosql-fmt", docUri)
     .update("lintConfigurationFilePath", value, target);
+}
+
+export async function updateFormattingConfigurationFilePath(
+  docUri: vscode.Uri,
+  value: string | undefined,
+  target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Workspace,
+): Promise<void> {
+  await vscode.workspace
+    .getConfiguration("uroborosql-fmt", docUri)
+    .update("configurationFilePath", value, target);
 }

--- a/client/src/test/helper.ts
+++ b/client/src/test/helper.ts
@@ -329,13 +329,3 @@ export async function updateLintConfigurationFilePath(
     .getConfiguration("uroborosql-fmt", docUri)
     .update("lintConfigurationFilePath", value, target);
 }
-
-export async function updateFormattingConfigurationFilePath(
-  docUri: vscode.Uri,
-  value: string | undefined,
-  target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Workspace,
-): Promise<void> {
-  await vscode.workspace
-    .getConfiguration("uroborosql-fmt", docUri)
-    .update("configurationFilePath", value, target);
-}


### PR DESCRIPTION


## Summary

`uroborosql-language-server` 移行後の `vscode-uroborosql-fmt` に、formatting failure の可視化を追加します。
対象：標準 formatting 経路である `Format Document`、`Format Selection`、`format on save` と、既存の明示コマンド `Format SQL` / `Format Selection as SQL` 

サーバ側では https://github.com/future-architect/uroborosql-fmt/pull/265 で、標準 formatting request の失敗を `null` ではなく LSP error として返す挙動へ変更しました。

この PR では拡張側で status bar を管理し、直近の formatting 成否を `normal` / `error` で反映するようにします。

## Changes

- status bar を生成するだけの実装をやめ、`normal` / `error` を切り替えられる controller に置き換え
- 標準 formatting 経路の middleware に status 更新処理を集約
- `vscode-languageclient` 由来の汎用トーストを抑止するため、`revealOutputChannelOn: RevealOutputChannelOn.Never` を設定
- `Format SQL` / `Format Selection as SQL` も同じ status controller を使うよう変更
- 明示コマンドの request 失敗時は既存どおり `showErrorMessage(...)` を維持しつつ、status も error に更新
- 標準 formatting 経路の failure → error と、その後の success → normal を e2e で追加検証

## Limitations

明示コマンドでは `workspace.applyEdit()` の戻り値を見て、version mismatch 相当の適用中断を status 変更なしで扱っています。

一方、標準 formatting 経路では VS Code の標準適用処理の成否を同じ粒度で観測できないため、status は edit provider / formatting request の成否を基準に更新しています。

## Notes

context: https://github.com/future-architect/vscode-uroborosql-fmt/pull/121#discussion_r3511683686

このPRは `feat/migrate-to-language-server` branch に向けており、変更は https://github.com/future-architect/vscode-uroborosql-fmt/pull/121 へ追加されます
