### PR TITLE
fix: support retrying extension publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,17 @@
 name: Publish
 on:
-  workflow_call: null
+  workflow_call:
+    inputs:
+      release_ref:
+        description: Tag or commit to publish
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Tag or commit to publish
+        required: true
+        type: string
   push:
     tags:
       - "*"
@@ -37,7 +48,7 @@ jobs:
           #   platform: alpine
           #   arch: x64
           #   npm_config_arch: x64
-          - os: macos-13
+          - os: macos-26-intel
             platform: darwin
             arch: x64
             npm_config_arch: x64
@@ -48,6 +59,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_ref }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json


### PR DESCRIPTION
## 変更内容

`.github/workflows/publish.yml`で定義している`Publish` workflowのrunner imageを更新し、既存リリースを手動で再公開する経路を追加しています。

- Darwin x64ビルドの廃止済み`macos-13` runnerを`macos-26-intel`へ変更
- 必須の`release_ref`を受け取る手動実行用`workflow_dispatch`を追加
- optionalな`release_ref`入力を追加

## 背景

[`v2.1.0`のRelease workflow](https://github.com/future-architect/vscode-uroborosql-fmt/actions/runs/29904898546)はタグとGitHub Releaseの作成までは成功したものの、Darwin x64のmatrix jobが廃止済みの`macos-13` runnerを待ち続けたため、VS Code Marketplaceへの公開には到達しませんでした。

停止していたrunはキャンセル済みであり、VS Code Marketplaceでは`v2.1.0`が未公開です。
この変更により、修正済みの`main`上にあるWorkflowから既存のリリースタグを再ビルドしてMarketplaceへ公開できます。

## Notes

通常のreusable workflow呼び出しとタグpushでは`release_ref`が空になるため、`actions/checkout`は従来どおり起動元のrefとcommitを解決します。

## マージ後の復旧手順

1. `main`上の`Publish` workflowを手動起動
2. `release_ref`へ`v2.1.0`を指定
3. 同じrunで全対象のVSIXが作成されたことを確認
4. VS Code Marketplaceで`2.1.0`が公開されたことを確認

この復旧ではタグ、GitHub Release、Changeset、package versionを再作成しません。