### PR TITLE
feat: upgrade vscode-languageclient to v10

### DIFF
--- a/.changeset/upgrade-languageclient-v10.md
+++ b/.changeset/upgrade-languageclient-v10.md
@@ -1,0 +1,7 @@
+---
+"uroborosql-fmt": minor
+---
+
+Upgrade `vscode-languageclient` from v7 to v10
+
+- Raise the minimum supported VS Code version to 1.91.0

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,6 +11,7 @@ client/node_modules/**
 !client/node_modules/vscode-languageclient/**
 !client/node_modules/vscode-languageserver-protocol/**
 !client/node_modules/vscode-languageserver-types/**
+!client/node_modules/vscode-languageserver-textdocument/**
 !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
 !client/node_modules/{semver,lru-cache,yallist}/**
 server/uroborosql-fmt-napi-*.tgz

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.1",
       "license": "BUSL-1.1",
       "dependencies": {
-        "vscode-languageclient": "^7.0.0"
+        "vscode-languageclient": "^10.0.0"
       },
       "devDependencies": {
-        "@types/vscode": "^1.74.0",
+        "@types/vscode": "^1.91.0",
         "@vscode/test-electron": "^3.0.0"
       },
       "engines": {
         "node": ">=24.14.0 <25",
-        "vscode": "^1.74.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -68,17 +68,24 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/chalk": {
@@ -122,11 +129,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -315,14 +317,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -523,39 +529,50 @@
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
+      "license": "MIT",
       "dependencies": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.16.0"
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
+      "license": "MIT"
+    },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -591,17 +608,16 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
       }
     },
     "chalk": {
@@ -624,11 +640,6 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -753,11 +764,11 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       }
     },
     "ms": {
@@ -894,33 +905,39 @@
       "dev": true
     },
     "vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw=="
     },
     "vscode-languageclient": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
       "requires": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.16.0"
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "requires": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw=="
+    },
     "vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -7,14 +7,14 @@
   "publisher": "Future",
   "repository": {},
   "engines": {
-    "vscode": "^1.74.0",
+    "vscode": "^1.91.0",
     "node": ">=24.14.0 <25"
   },
   "dependencies": {
-    "vscode-languageclient": "^7.0.0"
+    "vscode-languageclient": "^10.0.0"
   },
   "devDependencies": {
-    "@types/vscode": "^1.74.0",
+    "@types/vscode": "^1.91.0",
     "@vscode/test-electron": "^3.0.0"
   }
 }

--- a/client/src/command.ts
+++ b/client/src/command.ts
@@ -344,6 +344,7 @@ const hasOverlappingSelections = (
 const buildFormatAsSqlCommand =
   (
     client: LanguageClient,
+    readyPromise: Promise<void>,
     statusBar: Pick<StatusBarController, "showNormal" | "showError">,
     options: FormatAsSqlCommandOptions,
   ) =>
@@ -387,7 +388,7 @@ const buildFormatAsSqlCommand =
     };
 
     try {
-      await client.onReady();
+      await readyPromise;
       const result = await client.sendRequest<FormatSelectionAsSqlResponse>(
         FORMAT_SELECTIONS_AS_SQL_METHOD,
         params,
@@ -426,16 +427,18 @@ const buildFormatAsSqlCommand =
 
 export const buildFormatSelectionsAsSqlCommand = (
   client: LanguageClient,
+  readyPromise: Promise<void>,
   statusBar: Pick<StatusBarController, "showNormal" | "showError">,
 ) =>
-  buildFormatAsSqlCommand(client, statusBar, {
+  buildFormatAsSqlCommand(client, readyPromise, statusBar, {
     formatWholeDocumentWhenNoSelection: false,
   });
 
 export const buildFormatSqlCommand = (
   client: LanguageClient,
+  readyPromise: Promise<void>,
   statusBar: Pick<StatusBarController, "showNormal" | "showError">,
 ) =>
-  buildFormatAsSqlCommand(client, statusBar, {
+  buildFormatAsSqlCommand(client, readyPromise, statusBar, {
     formatWholeDocumentWhenNoSelection: true,
   });

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -73,17 +73,28 @@ export function activate(context: ExtensionContext): ExtensionApi {
     clientOptions,
   );
 
+  // Start the client. This will also launch the server.
+  const readyPromise = client.start();
+  // Consumers await this promise on their own timing (or never do, if the
+  // format commands are never invoked); attach a no-op catch here so a
+  // startup failure doesn't surface as an unhandled rejection.
+  readyPromise.catch((error) => {
+    client.outputChannel.appendLine(
+      `Failed to start language client: ${error}`,
+    );
+  });
+
   context.subscriptions.push(
     commands.registerCommand(
       "uroborosql-fmt.uroborosql-format",
-      buildFormatSqlCommand(client, statusBar),
+      buildFormatSqlCommand(client, readyPromise, statusBar),
     ),
   );
 
   context.subscriptions.push(
     commands.registerCommand(
       "uroborosql-fmt.format-selection-as-sql",
-      buildFormatSelectionsAsSqlCommand(client, statusBar),
+      buildFormatSelectionsAsSqlCommand(client, readyPromise, statusBar),
     ),
   );
 
@@ -114,11 +125,8 @@ export function activate(context: ExtensionContext): ExtensionApi {
 
   context.subscriptions.push(statusBar);
 
-  // Start the client. This will also launch the server
-  client.start();
-
   return {
-    onReady: () => client.onReady(),
+    onReady: () => readyPromise,
     getStatusState: () => statusBar.getState(),
   };
 }

--- a/client/src/test/mochaRunner.ts
+++ b/client/src/test/mochaRunner.ts
@@ -1,6 +1,6 @@
 import { readdir } from "fs/promises";
 import * as path from "path";
-import * as Mocha from "mocha";
+import Mocha = require("mocha");
 
 export const collectTestFiles = async (root: string): Promise<string[]> => {
   const entries = await readdir(root, { withFileTypes: true });

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "es2020",
     "lib": ["es2020"],
     "outDir": "out",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uroborosql-fmt",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uroborosql-fmt",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {
@@ -26,7 +26,7 @@
       },
       "engines": {
         "node": ">=24.14.0 <25",
-        "vscode": "^1.74.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "formatter"
   ],
   "engines": {
-    "vscode": "^1.74.0",
+    "vscode": "^1.91.0",
     "node": ">=24.14.0 <25"
   },
   "activationEvents": [


### PR DESCRIPTION

## Summary

`vscode-languageclient` を `^7.0.0` から `^10.0.0`（最新 10.1.0）へ更新します。

v9 以降で要求 VS Code バージョンが引き上がっているため、`engines.vscode` / `@types/vscode` も `^1.74.0` から `^1.91.0` へ合わせて引き上げました。

これにより、**VS Code 1.91 未満のユーザーには本バージョン以降の拡張が配信されなくなります**。

`vscode-languageclient` v8 で削除された `client.onReady()` を使用しているコードも修正しています。
あわせて、v10 の型公開方式の変更に合わせて `tsconfig.json` を調整しています。

## Changes

- `vscode-languageclient` を `^10.0.0` へ更新
- `engines.vscode` / `@types/vscode` を `^1.91.0` へ引き上げ
- v8 で削除された `client.onReady()` を、`client.start()` が返す Promise での待機に置き換え
- v10 は型定義を package.json の `exports` 経由でのみ公開するため、client の tsconfig を `node16` 系へ変更
- minor の changeset を追加
- root `package-lock.json` の `version` が `2.0.1` のままだった既存 drift の巻き込み修正

## Versioning

本 PR は minor update として扱っています。
`engines` 引き上げや依存ライブラリのメジャー更新のみの変更は、vscode-eslint や prettier-vscode などの主要拡張でも patch〜minor で扱われており major は拡張自体の破壊的な挙動変更を伴う場合に限られるため、それに合わせた判断です。

## After Merging

Renovate PR [#110](https://github.com/future-architect/vscode-uroborosql-fmt/pull/110) は `vscode-languageclient` の依存バージョンを書き換えるのみで、コード修正を含まないためビルドできません。
本 PR のマージ後に #110 をクローズします。

`vscode-languageserver` の v10 化（Renovate PR [#109](https://github.com/future-architect/vscode-uroborosql-fmt/pull/109)）は対象外とし、別途対応します。
