### PR TITLE
chore(server): remove unused language server dependencies

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,10 +9,7 @@
       "version": "1.0.0",
       "license": "BUSL-1.1",
       "dependencies": {
-        "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.1.1.tgz",
-        "vscode-languageserver": "^9.0.0",
-        "vscode-languageserver-textdocument": "^1.0.4",
-        "vscode-uri": "^3.0.7"
+        "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.1.1.tgz"
       },
       "engines": {
         "node": ">=24.14.0 <25"
@@ -26,49 +23,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -10,10 +10,7 @@
   },
   "repository": {},
   "dependencies": {
-    "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.1.1.tgz",
-    "vscode-languageserver": "^9.0.0",
-    "vscode-languageserver-textdocument": "^1.0.4",
-    "vscode-uri": "^3.0.7"
+    "uroborosql-fmt-napi": "file:uroborosql-fmt-napi-1.1.1.tgz"
   },
   "scripts": {}
 }


### PR DESCRIPTION

## Summary
`server` にて未使用依存となっていた `vscode-languageserver`, `vscode-languageserver-textdocument`, `vscode-uri` を削除しました。

## Background
PR [#121](https://github.com/future-architect/vscode-uroborosql-fmt/pull/121) で、`server` は Rust 実装（`uroborosql-fmt-napi` の `runLanguageServer()`）を呼ぶだけの薄いラッパーになりました。本来この時点で `vscode-languageserver`、`vscode-languageserver-textdocument`、`vscode-uri` を削除すべきところ漏れていたため、この PR で対応しています。

## After merging

`vscode-languageserver` の v10 化を提案する Renovate PR [#109](https://github.com/future-architect/vscode-uroborosql-fmt/pull/109) は、依存自体が不要になるためクローズします。（自動クローズされます）
